### PR TITLE
chore: enhance compress

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -24,6 +24,8 @@ export function readByteBits(byte) {
  * @param {number} bitLength max is 53
  */
 export function readUIntBits(val, bitLength) {
+  if (typeof val !== "number") throw new TypeError("val must be a number");
+
   if (val > Number.MAX_SAFE_INTEGER || val < 0) throw new RangeError("invalid number");
 
   const result = [];


### PR DESCRIPTION
1. 数组没有length，并且没有数据时默认长度为0
2. 数组的length可以从整个传入的json中的字段获取
3. 修复：bits类型支持encoder
4. skip增加fill参数，用于填充